### PR TITLE
Style changes + hiding the map

### DIFF
--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -26,17 +26,17 @@
           <opening-hours :business="business" :title="$t('label.seniorhours')" :senior="true"></opening-hours>
           <template v-if="!!business.instructions">
             <p>
-              <b>{{ $t('label.instructions') }}:</b><br />{{ business.instructions }}
+              <b>{{ $t('label.instructions') }}:</b> {{ business.instructions }}
             </p>
           </template>
           <template v-if="!!business.offers">
             <p>
-              <b>{{ $t('label.offers') }}:</b><br />{{ business.offers }}
+              <b>{{ $t('label.offers') }}:</b> {{ business.offers }}
             </p>
           </template>
           <template v-if="!!business.notes">
             <p>
-              <b>{{ $t('label.notes') }}:</b><br />{{ business.notes }}
+              <b>{{ $t('label.notes') }}:</b> {{ business.notes }}
             </p>
           </template>
         </p>

--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -1,85 +1,29 @@
 <template>
   <span>
-    <b-list-group class="list-group-flush">
-      <b-list-group-item variant="sideNav" button class="backtolist" @click="$emit('close-details')">
-        <i class="fas fa-arrow-left" />
-        {{ $t('label.backtolist') }}
-      </b-list-group-item>
-    </b-list-group>
     <b-list-group class="list-group-flush business-details">
-      <b-list-group-item variant="sideNav" :class="infotype">
-        <!-- <i class="fas" :class="icon" /> -->
-        <div>
-          <div class="title">
-            <i :class="businessIcon(business)"></i>
-            <div class="busName">
-              <h5>{{ business.provider_name }}</h5>
-              <span v-if="!!business.provider_addloc">{{ business.provider_addloc }}</span>
-              <!-- <template v-if="!!business.marker.cuisine">{{ business.marker.cuisine }}</template> -->
-            </div>
-          </div>
-          <p>
-            <b>{{ $t('label.address') }}:</b><br />
-            {{ business.address }}, {{ business.city }}, {{ business.state }}
-            {{ business.zip }}<br />
-            <a :href="businessGoogleMapUrl">
-              View on Google Maps
-            </a>
-          </p>
-
-          <p>
-            <icon-list-item
-              v-if="business.discount_medical == 1"
-              icon="fas fa-user-md"
-              :title="$tc('label.discount_medical', 1)"
-            />
-            <icon-list-item v-if="business.family_meal == 1" icon="fas fa-user-friends" :title="$tc('category.family', 2)" />
-            <icon-list-item v-if="business.meal_student == 1" icon="fas fa-school" :title="$tc('label.meal_student', 1)" />
-            <icon-list-item v-if="business.meal_public == 1" icon="fas fa-users" :title="$tc('label.meal_public', 1)" />
-            <icon-list-item v-if="business.free_produce == 1" icon="fas fa-apple-alt" :title="$tc('label.free_produce', 1)" />
-            <icon-list-item
-              v-if="business.free_groceries == 1"
-              icon="fas fa-shopping-basket"
-              :title="$tc('label.free_groceries', 1)"
-            />
-            <icon-list-item v-if="business.curbside == 1" icon="fas fa-car" :title="$tc('label.curbside', 1)" />
-            <icon-list-item v-if="business.drive_thru == 1" icon="fas fa-car-side" :title="$t('label.drive_thru')" />
-            <icon-list-item v-if="business.order_online == 1" icon="fas fa-mouse" :title="$t('label.order_online')" />
-            <icon-list-item v-if="business.delivery == 1" icon="fas fa-shipping-fast" :title="$t('label.delivery')" />
-          </p>
-          <p>
-            <icon-list-item
-              v-if="!!business.contact"
-              icon="fas fa-phone-alt"
-              :title="business.contact"
-              :link="'tel:' + business.contact"
-            />
-
-            <!-- <icon-list-item
-              v-if="!!business.marker.contactspanish"
-              icon="fas fa-phone-alt"
-              :title="business.marker.contactspanish + ' (' + $t('languages.es').toLowerCase() + ')'"
-              :link="'tel:' + business.marker.contactspanish"
-            /> -->
-
-            <icon-list-item
-              v-if="!!business.web_link"
-              icon="fas fa-globe"
-              :title="getDomain(business.web_link)"
-              :link="business.web_link"
-            />
-
-            <icon-list-item
-              v-if="!!business.email"
-              icon="fas fa-envelope"
-              :title="getDomain(business.email)"
-              :link="'mailto:' + business.email"
-            />
-          </p>
+      <div>
+        <p>
+          <icon-list-item v-if="business.discount_medical == 1" icon="fas fa-user-md" :title="$tc('label.discount_medical', 1)" />
+          <icon-list-item v-if="business.family_meal == 1" icon="fas fa-user-friends" :title="$tc('category.family', 2)" />
+          <icon-list-item v-if="business.meal_student == 1" icon="fas fa-school" :title="$tc('label.meal_student', 1)" />
+          <icon-list-item v-if="business.meal_public == 1" icon="fas fa-users" :title="$tc('label.meal_public', 1)" />
+          <icon-list-item v-if="business.free_produce == 1" icon="fas fa-apple-alt" :title="$tc('label.free_produce', 1)" />
+          <icon-list-item v-if="business.free_groceries == 1" icon="fas fa-shopping-basket" :title="$tc('label.free_groceries', 1)" />
+          <icon-list-item v-if="business.curbside == 1" icon="fas fa-car" :title="$tc('label.curbside', 1)" />
+          <icon-list-item v-if="business.drive_thru == 1" icon="fas fa-car-side" :title="$t('label.drive_thru')" />
+          <icon-list-item v-if="business.order_online == 1" icon="fas fa-mouse" :title="$t('label.order_online')" />
+          <icon-list-item v-if="business.delivery == 1" icon="fas fa-shipping-fast" :title="$t('label.delivery')" />
+          <icon-list-item v-if="!!business.web_link" icon="fas fa-globe" :title="getDomain(business.web_link)" :link="business.web_link" />
+          <icon-list-item
+            v-if="!!business.email"
+            icon="fas fa-envelope"
+            :title="getDomain(business.email)"
+            :link="'mailto:' + business.email"
+          />
+        </p>
+        <p>
           <opening-hours :business="business" :title="$t('label.openinghours')"></opening-hours>
-
           <opening-hours :business="business" :title="$t('label.seniorhours')" :senior="true"></opening-hours>
-
           <template v-if="!!business.instructions">
             <p>
               <b>{{ $t('label.instructions') }}:</b><br />{{ business.instructions }}
@@ -95,9 +39,10 @@
               <b>{{ $t('label.notes') }}:</b><br />{{ business.notes }}
             </p>
           </template>
-          <p class="updated">Details last updated: {{ business.last_update }}</p>
-        </div>
-      </b-list-group-item>
+        </p>
+
+        <p class="updated">Details last updated: {{ business.last_update }}</p>
+      </div>
     </b-list-group>
   </span>
 </template>
@@ -131,9 +76,7 @@ export default {
     businessGoogleMapUrl() {
       var url =
         'https://www.google.com/maps/search/?api=1&query=' +
-        (this.business.provider_addloc
-          ? encodeURI(this.business.provider_addloc)
-          : encodeURI(this.business.provider_name)) +
+        (this.business.provider_addloc ? encodeURI(this.business.provider_addloc) : encodeURI(this.business.provider_name)) +
         '+' +
         encodeURI(this.business.address) +
         '+' +
@@ -151,54 +94,10 @@ export default {
 
 <style scoped lang="scss">
 .business-details {
-  max-height: calc(100vh - 237px);
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-.backtolist {
-  font-size: 0.8rem;
-
-  i {
-    margin-right: 0.375rem;
-  }
-
-  // &:hover {
-  //   background: rgba(0, 0, 0, 0.05) !important;
-  //   cursor: pointer;
-  // }
-}
-
-.title {
-  margin: 0 0 0.75rem 0;
-  display: inline-block;
-
-  i {
-    font-size: 3rem;
-    color: #ee8842;
-    margin: 7px 10px 7px 0;
-    float: left;
-  }
-}
-
-.busName {
-  margin-left: 54px;
-  width: 208px;
-}
-
-.green {
-  font-size: 0.8rem;
-  // color: #666;
-
-  & > div {
-    width: 243px;
-  }
+  background-color: transparent;
 }
 
 .updated {
   color: #aaa;
-}
-
-a {
-  color: #ee8842 !important;
 }
 </style>

--- a/covid-19-support/src/components/IconListItem.vue
+++ b/covid-19-support/src/components/IconListItem.vue
@@ -56,8 +56,9 @@ export default {
 }
 
 .ilIcon {
-  font-size: 1.2rem;
-  width: 33px;
+  font-size: 1rem;
+  width: 28px;
+  color: $teal;
 }
 
 .ilTitle {

--- a/covid-19-support/src/components/IconListItem.vue
+++ b/covid-19-support/src/components/IconListItem.vue
@@ -51,10 +51,7 @@ export default {
     display: inline-block;
     line-height: 1.2rem;
     vertical-align: middle;
-    margin: 0.25rem 0;
-  }
-  a {
-    color: #ee8842 !important;
+    margin: 4px 0;
   }
 }
 

--- a/covid-19-support/src/components/OpeningHours.vue
+++ b/covid-19-support/src/components/OpeningHours.vue
@@ -64,7 +64,7 @@ export default {
               break
             case 1:
               if (this.business[attr] == 0) {
-                myDays.push({ name: dayName, val: this.$t('label.closed'), class: 'closed' })
+                myDays.push({ name: dayName, val: this.$t('label.closed'), class: 'openingHoursClosed' })
               } else {
                 // myDays.push({ name: dayName, val: this.$t('label.normalhours') })
                 // cnt++
@@ -96,8 +96,5 @@ export default {
 .oh-name {
   padding-right: 20px;
   vertical-align: top;
-}
-.closed {
-  color: #ff2c1c;
 }
 </style>

--- a/covid-19-support/src/components/OpeningHours.vue
+++ b/covid-19-support/src/components/OpeningHours.vue
@@ -4,7 +4,7 @@
       <b>{{ title }}</b>
     </div>
     <table>
-      <tr v-for="(item, index) in days" :key="index">
+      <tr v-for="(item, index) in days" :key="index" class="oh-row">
         <!-- <i class="fas" :class="icon" /> -->
         <td class="oh-name">{{ item.name }}</td>
         <td :class="item.class"><span v-html="item.val"></span></td>
@@ -91,10 +91,17 @@ export default {
 
 <style>
 .openhours {
-  margin-bottom: 10px;
+  margin-bottom: 16px;
+}
+.oh-title {
+  font-size: 0.9rem;
+  margin-bottom: 4px;
 }
 .oh-name {
-  padding-right: 20px;
+  padding: 2px 20px 2px 0;
   vertical-align: top;
+}
+.oh-row {
+  padding-bottom: 4px;
 }
 </style>

--- a/covid-19-support/src/components/Results.vue
+++ b/covid-19-support/src/components/Results.vue
@@ -14,14 +14,6 @@
       <filters :need="$route.params.need" :markers="markers" :activeFilters="activeFilters" @box-selected="boxSelected" />
       <results-list :markers="markers" :resource="resourceData" @resource-selected="passSelectedMarker" />
     </div>
-
-    <!-- <BusinessDetails
-      :infotype="'green'"
-      :icon="'fa-tractor'"
-      :business="currentBusiness"
-      v-if="currentBusiness != null"
-      @close-details="closeDetails"
-    ></BusinessDetails> -->
   </div>
 </template>
 

--- a/covid-19-support/src/components/Results.vue
+++ b/covid-19-support/src/components/Results.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="results">
+  <div id="results" :class="{ noMap: !displayMap }">
     <div id="map-details">
       <resource-map
         v-if="displayMap"
@@ -57,7 +57,7 @@ export default {
   created() {
     const query = encodeURI(sqlQueries[this.$route.params.need])
     this.fetchData(query)
-    console.log("results created")
+    console.log('results created')
   },
   methods: {
     async fetchData(query) {
@@ -72,7 +72,7 @@ export default {
     },
     boxSelected: function (filter) {
       this.activeFilters = addOrRemove(this.activeFilters, filter)
-      console.log("in results.boxSelected")
+      console.log('in results.boxSelected')
       // console.log(this.activeFilters)
     },
     centerUpdated(center) {
@@ -82,7 +82,7 @@ export default {
       this.bounds = bounds
     },
     passSelectedMarker: function (val) {
-      console.log("passSelectedMarker")
+      console.log('passSelectedMarker')
       console.log(val)
       this.resourceData = val
       this.showList = false
@@ -149,15 +149,14 @@ export default {
     }
   },
   watch: {
-    $route: function(to, from) {
+    $route: function (to, from) {
       // update entries based on need
-      console.log("changing route")
+      console.log('changing route')
       if (to.params && to.params.need && to.params.need != from.params.need) {
         const query = encodeURI(sqlQueries[to.params.need])
         this.activeFilters = []
         // console.log(this.activeFilters)
         this.fetchData(query)
-
       }
     }
   }
@@ -172,6 +171,10 @@ export default {
   flex: 1 1 auto;
   flex-direction: column;
   position: absolute;
+}
+
+.noMap {
+  position: relative !important;
 }
 
 #map-details {

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -56,7 +56,6 @@
 </template>
 
 <script>
-import { dayFilters } from '@/constants'
 import BusinessDetails from '@/components/BusinessDetails.vue'
 
 export default {
@@ -89,14 +88,11 @@ export default {
     // }
   },
   methods: {
-    getClosedMessage: function () {
+    getClosedMessage() {
       return this.$t(`label.closed-today`)
     },
-    getOpenMessage(item) {
-      var today = new Date().getDay()
-      const dayFilter = dayFilters[today]
-
-      return this.$t('open-today') + ': ' + item[dayFilter]
+    getOpenMessage() {
+      return this.$t('label.open-today')
     }
   },
   computed: {

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -10,23 +10,22 @@
         :ref="'result' + item.cartodb_id"
         @click="$emit('resource-selected', { resourceId: item.cartodb_id, isSetByMap: false })"
       >
-      <div class='left'>
         <template v-if="!!item.provider_addloc">
           <div class="addloc">{{ item.provider_addloc }}</div>
         </template>
-        <span class="resultTitle">{{ item.provider_name }}</span>
-        <span class="resultAddress">
-          <!-- <span v-if="!!item.cuisine">{{ item.cuisine }}<br /></span> -->
-          {{ item.address }},
-          {{ item.city }}
-        </span>
-        <div class="resultContact">{{ item.contact }}</div>
-      </div>
-      <div class='right'>
-         <span v-if="!item.isOpen" class="closed">{{ getClosedMessage() }}</span>
+        <div class="resultMetadata">
+          <span class="resultTitle">{{ item.provider_name }}</span>
+          <span class="resultAddress">
+            <!-- <span v-if="!!item.cuisine">{{ item.cuisine }}<br /></span> -->
+            {{ item.address }},
+            {{ item.city }}
+          </span>
+          <a class="resultContact" :href="'tel:' + item.contact">{{ item.contact }}</a>
+        </div>
+        <span v-if="!item.isOpen" class="closed">{{ getClosedMessage() }}</span>
         <span v-if="item.isOpen" class="open">{{ getOpenMessage(item) }}</span>
-        <div>More info</div>
-      </div>
+        <business-details v-if="item.cartodb_id == resource.resourceId" :business="item" />
+        <!-- <div>More info</div> -->
         <!-- <template v-if="item.family_meal == 1"
           ><span :title="$tc('category.family', 2)"><i class="fas fa-user-friends" /></span
         ></template>
@@ -58,6 +57,8 @@
 
 <script>
 import { dayFilters } from '@/constants'
+import BusinessDetails from '@/components/BusinessDetails.vue'
+
 export default {
   name: 'ResultsList',
   data() {
@@ -66,17 +67,19 @@ export default {
       today: new Date().getDay()
     }
   },
-  components: {},
+  components: {
+    BusinessDetails
+  },
   props: {
     markers: Array,
     resource: { resourceId: Number, isSetByMap: Boolean }
   },
   watch: {
     resource: function (val) {
-      console.log("scroll based on resourceSelected change")
-        var top = this.$refs['result'+ val.resourceId][0].offsetTop - this.$refs['result'+ this.markers[0].cartodb_id][0].offsetTop
-        this.$refs['results'].scrollTo(0, top)
-    }//,
+      console.log('scroll based on resourceSelected change')
+      var top = this.$refs['result' + val.resourceId][0].offsetTop - this.$refs['result' + this.markers[0].cartodb_id][0].offsetTop
+      this.$refs['results'].scrollTo(0, top)
+    } //,
     // markers: function () {
     //   console.log(this.$refs)
     //   if (this.resource && typeof this.$refs['result' + this.resource.resourceId] !== []) {
@@ -128,7 +131,6 @@ export default {
   font-size: 0.8rem;
 }
 
-
 .resultList {
   z-index: 2000;
   width: 100%;
@@ -138,8 +140,7 @@ export default {
 .resultItem {
   padding: 16px;
   width: 100%;
-  /* display: block; */
-  display: flex;
+  display: block;
   flex: 1 1 auto;
   border-bottom: solid 1px rgba(0, 0, 0, 0.125);
   font-size: 0.8rem;
@@ -161,17 +162,6 @@ export default {
       background: $gray-900;
     }
   }
-
-  a {
-    color: #000;
-  }
-
-  & > span > i {
-    margin-right: 8px;
-    color: #2eb7cb;
-    font-size: 1rem;
-    margin-top: 6px;
-  }
 }
 
 .resultTitle {
@@ -179,6 +169,10 @@ export default {
   font-weight: 600;
   display: inline-block;
   margin: 0 0 4px;
+}
+
+.resultMetadata {
+  margin-bottom: 12px;
 }
 
 .resultAddress {
@@ -189,14 +183,23 @@ export default {
 
 .closed,
 .open {
-}
-
-.closed {
-  color: grey;
+  display: inline-block;
+  border-radius: 100px;
+  background-color: white;
+  border: 1px solid;
+  padding: 2px 6px;
+  margin-bottom: 8px;
 }
 
 .open {
-  color: green;
+  border-color: $gray-400;
+  color: grey;
+}
+
+.closed {
+  border-color: $gray-700;
+  background-color: $gray-700;
+  color: white;
 }
 
 .no-result {


### PR DESCRIPTION
1. Adding `BusinessHours` back into `ResultsList` when a result item is expanded (and modifying `BusinessHours` so that it looks as expected within the context of a result item):
![Screen Recording 2020-05-13 at 09 42 PM](https://user-images.githubusercontent.com/1114632/81893714-fbad6580-9562-11ea-8c64-2a2a61bc68dd.gif)

2. Fixing styling for when the map is hidden (ie. making it so that the filters and list appear *under the dropdowns* without overlapping)
<img width="325" alt="Image 2020-05-13 at 9 42 38 PM" src="https://user-images.githubusercontent.com/1114632/81893748-18e23400-9563-11ea-9b8e-bb366efb2958.png">
