### PR TITLE
Change basemap URL to Mapbox style

### DIFF
--- a/covid-19-support/src/components/Results.vue
+++ b/covid-19-support/src/components/Results.vue
@@ -55,7 +55,7 @@ export default {
   data() {
     return {
       entries: null,
-      mapUrl: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png',
+      mapUrl: 'https://api.mapbox.com/styles/v1/stanford-datalab/ckad39evg02u11ijqeghbn0u0/tiles/{z}/{x}/{y}?access_token=',
       bounds: null,
       centroid: [null, null],
       resourceData: { resourceId: null, isSetByMap: false },


### PR DESCRIPTION
I think this is the only piece that needs to change in this file, with the rest (including Mapbox access token) needing changes in ResourceMap.vue - but I'm not familiar with this code structure! There are other references to Carto in here that I'm not sure if it's going to cause problems or if that's just about the database.