### PR TITLE
Reset Zoom

### DIFF
--- a/covid-19-support/src/components/ResourceMap.vue
+++ b/covid-19-support/src/components/ResourceMap.vue
@@ -73,7 +73,8 @@ export default {
     mapUrl: String,
     nearLatLonZoom: { lat: Number, lon: Number, zoom: Number },
     resource: { resourceId: Number, isSetByMap: Boolean },
-    zoomDiff: Number
+    zoomDiff: Number,
+    zoomReset: Boolean
   },
   data() {
     return {
@@ -153,6 +154,13 @@ export default {
     zoomDiff: function (val) {
       if (val > 0) {
         this.$refs.covidMap.mapObject.zoomOut(val, { duration: 1 })
+      }
+    },
+    zoomReset: function (val) {
+      if (val) {
+        this.$refs.covidMap.mapObject.setView(latLng(this.nearLatLonZoom.lat, this.nearLatLonZoom.lon), this.nearLatLonZoom.zoom, {
+          duration: 1
+        })
       }
     },
     showKey: function (val) {

--- a/covid-19-support/src/components/Results.vue
+++ b/covid-19-support/src/components/Results.vue
@@ -11,6 +11,7 @@
         :nearLatLonZoom="nearLatLonZoom"
         :resource="resourceData"
         :zoomDiff="zoomDiff"
+        :zoomReset="zoomReset"
       />
       <div id="result-details" ref="result-details" :class="{ noMap: !displayMap }">
         <filters
@@ -26,6 +27,7 @@
           :markers="markers"
           :resource="resourceData"
           @resource-selected="passSelectedMarker"
+          @reset-zoom="resetZoom"
           @zoom-out="zoomOut"
           :displayMap="displayMap"
           @scroll="scroll"
@@ -62,7 +64,8 @@ export default {
       centroid: [null, null],
       resourceData: { resourceId: null, isSetByMap: false },
       activeFilters: [],
-      zoomDiff: 0
+      zoomDiff: 0,
+      zoomReset: false
     }
   },
   created() {
@@ -97,6 +100,10 @@ export default {
     zoomOut() {
       this.zoomDiff = 2
       this.$nextTick(() => (this.zoomDiff = 0))
+    },
+    resetZoom() {
+      this.zoomReset = true
+      this.$nextTick(() => (this.zoomReset = false))
     },
     scroll(offset) {
       if (this.displayMap) {

--- a/covid-19-support/src/components/Results.vue
+++ b/covid-19-support/src/components/Results.vue
@@ -27,6 +27,7 @@
           :markers="markers"
           :resource="resourceData"
           @resource-selected="passSelectedMarker"
+          @resource-unselected="unselectResource"
           @reset-zoom="resetZoom"
           @zoom-out="zoomOut"
           :displayMap="displayMap"
@@ -65,7 +66,8 @@ export default {
       resourceData: { resourceId: null, isSetByMap: false },
       activeFilters: [],
       zoomDiff: 0,
-      zoomReset: false
+      zoomReset: false,
+      mapMoved: false
     }
   },
   created() {
@@ -87,8 +89,17 @@ export default {
     boxSelected: function (filter) {
       this.activeFilters = addOrRemove(this.activeFilters, filter)
     },
+    isCenteredOn(marker) {
+      return marker && Math.abs(marker.lat - this.centroid[0]) < 0.0001 && Math.abs(marker.lon - this.centroid[1]) < 0.0001
+    },
     centerUpdated(center) {
       this.centroid = [center.lat, center.lng]
+      if (!this.isCenteredOn(this.currentBusiness)) {
+        this.mapMoved = true
+      }
+      if (this.isCenteredOn(this.nearLatLonZoom)) {
+        this.mapMoved = false
+      }
     },
     boundsUpdated: function (bounds) {
       this.bounds = bounds
@@ -104,6 +115,11 @@ export default {
     resetZoom() {
       this.zoomReset = true
       this.$nextTick(() => (this.zoomReset = false))
+    },
+    unselectResource() {
+      if (!this.mapMoved) {
+        this.resetZoom()
+      }
     },
     scroll(offset) {
       if (this.displayMap) {

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -62,7 +62,7 @@
           />
         </div>
       </div>
-      <a class="more-result bottom" href="#" @click="zoomOut" v-if="displayMap">{{ $tc('label.zoom_out_for_more_results') }}</a>
+      <a class="more-result bottom" href="#" @click="resetZoom" v-if="displayMap">{{ $tc('label.reset_zoom') }}</a>
     </div>
   </div>
 </template>
@@ -144,6 +144,9 @@ export default {
     zoomOut() {
       this.$emit('zoom-out')
       this.showDetails = false
+    },
+    resetZoom() {
+      this.$emit('reset-zoom')
     }
   },
   computed: {

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -135,10 +135,12 @@ export default {
       return item[field]
     },
     resourceClicked(item) {
-      if (!this.resource.resourceId || item.cartodb_id != this.resource.resourceId) {
+      if (!this.resource.resourceId || item.cartodb_id != this.resource.resourceId || !this.showDetails) {
+        this.showDetails = true
         this.$emit('resource-selected', { resourceId: item.cartodb_id, isSetByMap: false })
       } else {
-        this.showDetails = !this.showDetails
+        this.showDetails = false
+        this.$emit('resource-unselected')
       }
     },
     zoomOut() {

--- a/covid-19-support/src/locales/en.json
+++ b/covid-19-support/src/locales/en.json
@@ -170,6 +170,7 @@
     " ebt_pay_online": "Pay with EBT online",
     "open_today": "Open today",
     "pay_phone": "Pay with EBT over the phone",
+    "reset_zoom": "Reset Zoom",
     "safe_pick_up": "Safe pick-up options",
     "zoom_out_for_more_results": "Zoom out for more results.",
     "in_person": "In-person clinics",


### PR DESCRIPTION
1) (Pending translation) Swap out the zoom out button for a reset zoom button

2) (Translation not needed) Automatically resets the zoom when a user closes a resource, unless the map has been moved (this part doesn't require translations). Basically this is to enable the use case where a user wants to spam click through everything in the results list (pretty much how I browse Google/Yelp for example)