### PR TITLE
Show 'Loading...' instead of 'No results' while loading

### DIFF
--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="resultWrapper" ref="results">
     <div class="resultList">
+      <div v-if="isLoading" class="no-result">
+        {{ $t('label.loading') }}
+      </div>
       <div v-if="isEmpty && displayMap" class="no-result">
         {{ $tc('no_location_in_this_area') }}
         <a class="more-result" href="#" @click="zoomOut" v-if="displayMap">{{ $tc('label.zoom_out_for_more_results') }}</a>
@@ -147,8 +150,11 @@ export default {
     }
   },
   computed: {
+    isLoading() {
+      return this.markers == null
+    },
     isEmpty() {
-      return !this.markers || this.markers.length == 0
+      return this.markers != null && this.markers.length == 0
     },
     legalResources() {
       return this.$route.params.need.startsWith('legal')

--- a/covid-19-support/src/locales/en.json
+++ b/covid-19-support/src/locales/en.json
@@ -163,6 +163,7 @@
     "freemeals": "Free meal location|Free meal locations",
     "free_produce": "Free produce location|Free produce locations",
     "instructions": "Instructions",
+    "loading": "Loading...",
     "mapkey": "Map Key",
     "meal_public": "Meals open to public",
     "meal_student": "Meals for children",


### PR DESCRIPTION
Only have an English translation for 'Loading...' right now. It only shows up for like a second but it's confusing if it says 'No results' regardless