### PR TITLE
Remove P-EBT banner

### DIFF
--- a/covid-19-support/src/App.vue
+++ b/covid-19-support/src/App.vue
@@ -80,7 +80,7 @@ export default {
       errorStr: null,
       initialSearch: false,
       isNavBarOpen: false,
-      showBanner: true
+      showBanner: false
     }
   },
   methods: {


### PR DESCRIPTION
Closes #45. I keep the banner code, since it will be useful if we want to put up another banner (we just swap out the P-EBT text)