### PR TITLE
Change date string formatting on last updated text

### DIFF
--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -41,7 +41,10 @@
           </template>
         </p>
 
-        <p class="updated">{{ $t('label.last_updated') }}: {{ business.last_update }}</p>
+        <p class="updated">
+          {{ $t('label.last_updated') }}:
+          {{ new Date(business.last_update).toLocaleDateString(this.$i18n.locale, { year: 'numeric', month: '2-digit', day: '2-digit' }) }}
+        </p>
       </div>
     </b-list-group>
   </span>
@@ -51,6 +54,7 @@
 import OpeningHours from '@/components/OpeningHours.vue'
 import IconListItem from '@/components/IconListItem.vue'
 import { businessIcon } from '@/utilities'
+
 export default {
   name: 'BusinessDetails',
   components: {


### PR DESCRIPTION
Closes [issue #14: Fix the "Last Updated" text bug](https://github.com/codeforsanjose/bac-resources/issues/14)

Update the "Details last updated" text to a more human-readable date format. This date format also matches the currently selected locale. Examples of English and Spanish dates below:

<img width="1552" alt="en" src="https://user-images.githubusercontent.com/4879368/102511837-205c4500-403e-11eb-81f1-3934b787ba7b.png">
<img width="1552" alt="es" src="https://user-images.githubusercontent.com/4879368/102511861-25b98f80-403e-11eb-8c93-08343a747ff8.png">