### PR TITLE
Enlarge the "Details Last Updated" text in the tooltip. #74

### DIFF
--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -103,5 +103,6 @@ export default {
 
 .updated {
   color: #aaa;
+  font-size: 15px;
 }
 </style>


### PR DESCRIPTION
# Screenshot
<img width="463" alt="Screen Shot 2021-03-28 at 9 24 25 AM" src="https://user-images.githubusercontent.com/26678464/112759342-657e0480-8fa7-11eb-9a01-7c518e59bafb.png">

Closes #74