### PR TITLE
Move production deploy to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@ and medical help.
 
 From the `covid-19-support` directory:
 - Run locally: `npm run serve`
-- Deploy to staging: `env VUE_APP_DEPLOY="GITHUB" npm run build && npm run deploy`
-- Deploy to production: `npm run build && bash deploy_aws.sh`
-
-You can find the login credentials for AWS in the Google Drive. See the AWS docs for
-[How to login](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+- Deploy to production: `npm run build && npm run deploy`
 
 ## This project is
 

--- a/covid-19-support/package.json
+++ b/covid-19-support/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vue-cli-service test:unit",
     "lint": "eslint src && prettier --check .",
     "format": "prettier --write .",
-    "deploy": "gh-pages -d dist"
+    "deploy": "echo 'bayareacommunity.org' > dist/CNAME && gh-pages -d dist"
   },
   "dependencies": {
     "@kazupon/vue-i18n-loader": "^0.5.0",

--- a/covid-19-support/vue.config.js
+++ b/covid-19-support/vue.config.js
@@ -1,7 +1,7 @@
 const CompressionPlugin = require('compression-webpack-plugin')
 
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production' && process.env.VUE_APP_DEPLOY == 'GITHUB' ? '/mega-map-dev/' : '/',
+  publicPath: '/',
 
   pluginOptions: {
     i18n: {


### PR DESCRIPTION
My AWS account expired, so I update the CNAME, deploy scripts, and documentation here.